### PR TITLE
Add `publicKey` field to `BankrunProvider`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,10 +64,12 @@ class BankrunConnectionProxy implements ConnectionInterface {
 
 export class BankrunProvider implements Provider {
 	wallet: Wallet;
+	publicKey: PublicKey;
 	connection: Connection;
 
 	constructor(public context: ProgramTestContext) {
 		this.wallet = new NodeWallet(context.payer);
+		this.publicKey = this.wallet.publicKey;
 		this.connection = new BankrunConnectionProxy(
 			context.banksClient,
 		) as unknown as Connection; // uh


### PR DESCRIPTION
In my tests, I use anchor's `createInstruction` ([example usage](https://github.com/coral-xyz/multisig/blob/435d6eb15f10c9e99d81323890bc042cfcaa402f/tests/multisig.js#L30-L34)). This function [requires the provider to have a `publicKey` field](https://github.com/coral-xyz/anchor/blob/eea252d725998bedd743fa650056e71fd4fcdd81/ts/packages/anchor/src/program/namespace/account.ts#L358-L362), so I've added one.

I tested locally that `createInstruction` now works. I didn't check in this test code bcuz it wouldn't really make sense to do it like this in this test (it only really makes sense when you have an `#[account(zero)]`), and I didn't want to confuse any future readers.