### PR TITLE
expose publicKey and add wallet to provider constructor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,12 +65,14 @@ class BankrunConnectionProxy implements ConnectionInterface {
 export class BankrunProvider implements Provider {
 	wallet: Wallet;
 	connection: Connection;
+	publicKey: PublicKey;
 
-	constructor(public context: ProgramTestContext) {
-		this.wallet = new NodeWallet(context.payer);
+	constructor(public context: ProgramTestContext, wallet?: Wallet) {
+		this.wallet = wallet || new NodeWallet(context.payer);
 		this.connection = new BankrunConnectionProxy(
 			context.banksClient,
 		) as unknown as Connection; // uh
+		this.publicKey = this.wallet.publicKey;
 	}
 
 	async send?(

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -3,6 +3,7 @@ import { BankrunProvider } from "anchor-bankrun";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import { BN, Program } from "@coral-xyz/anchor";
 import { IDL as PuppetIDL, Puppet } from "./anchor-example/puppet";
+import NodeWallet from "@coral-xyz/anchor/dist/cjs/nodewallet";
 
 const PUPPET_PROGRAM_ID = new PublicKey(
 	"Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS",
@@ -40,4 +41,19 @@ test("anchor", async () => {
 		puppetKeypair.publicKey,
 	);
 	expect(dataAccount.data.eq(new BN(123456)));
+});
+
+test("bankrun provider with wallet", async () => {
+	const context = await startAnchor("tests/anchor-example", [], []);
+
+	const provider = new BankrunProvider(context);
+
+	expect(provider.publicKey.equals(context.payer.publicKey));
+
+	// another provider from a second wallet
+	const wallet = new NodeWallet(Keypair.generate());
+
+	const newProvider = new BankrunProvider(context, wallet);
+
+	expect(wallet.publicKey.equals(newProvider.publicKey));
 });


### PR DESCRIPTION
upgrading from an `AnchorProvider` is tough because it exposes the `publicKey` directly, this will help.

also adds an optional `wallet` parameter so creating a new `BankrunProvider` from an existing context (multiple signers) is easier.