### PR TITLE
Use peer dependencies instead of normal dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
 	"files": ["dist/"],
 	"license": "MIT",
 	"devDependencies": {
+		"@coral-xyz/anchor": "^0.28.0",
+		"@solana/web3.js": "^1.78.4",
 		"@types/bn.js": "^5.1.1",
 		"@types/bs58": "^4.0.1",
 		"@types/jest": "^29.5.3",
@@ -13,6 +15,7 @@
 		"bs58": "^4.0.1",
 		"jest": "^29.6.1",
 		"rome": "^12.0.0",
+		"solana-bankrun": "^0.2.0",
 		"ts-jest": "^29.1.1",
 		"ts-node": "^10.9.1",
 		"typescript": "^5.0.4"
@@ -30,8 +33,9 @@
 		"bumpMajor": "yarn version --no-git-tag-version --major"
 	},
 	"packageManager": "yarn@3.5.1",
-	"dependencies": {
-		"@coral-xyz/anchor": "^0.28.0",
-		"solana-bankrun": "^0.1.1"
+	"peerDependencies": {
+		"@coral-xyz/anchor": "0.x",
+		"@solana/web3.js": "1.x",
+		"solana-bankrun": "0.x"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -259,9 +259,9 @@
     "@babel/helper-plugin-utils" "^7.22.5"
 
 "@babel/runtime@^7.17.2", "@babel/runtime@^7.22.6":
-  version "7.22.10"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.10.tgz#ae3e9631fd947cb7e3610d3e9d8fef5f76696682"
-  integrity sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==
+  version "7.22.15"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.15.tgz#38f46494ccf6cf020bd4eed7124b425e83e523b8"
+  integrity sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==
   dependencies:
     regenerator-runtime "^0.14.0"
 
@@ -589,16 +589,16 @@
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@noble/curves@^1.0.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.1.0.tgz#f13fc667c89184bc04cccb9b11e8e7bae27d8c3d"
-  integrity sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.2.0.tgz#92d7e12e4e49b23105a2555c6984d41733d65c35"
+  integrity sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==
   dependencies:
-    "@noble/hashes" "1.3.1"
+    "@noble/hashes" "1.3.2"
 
-"@noble/hashes@1.3.1", "@noble/hashes@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.1.tgz#8831ef002114670c603c458ab8b11328406953a9"
-  integrity sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==
+"@noble/hashes@1.3.2", "@noble/hashes@^1.3.1":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
+  integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
 
 "@rometools/cli-darwin-arm64@12.1.3":
   version "12.1.3"
@@ -656,7 +656,7 @@
   dependencies:
     buffer "~6.0.3"
 
-"@solana/web3.js@^1.68.0":
+"@solana/web3.js@^1.68.0", "@solana/web3.js@^1.78.4":
   version "1.78.4"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.78.4.tgz#e8ca9abe4ec2af5fc540c1d272efee24aaffedb3"
   integrity sha512-up5VG1dK+GPhykmuMIozJZBbVqpm77vbOG6/r5dS7NBGZonwHfTLdBbsYc3rjmaQ4DpCXUa3tUc4RZHRORvZrw==
@@ -745,9 +745,9 @@
     base-x "^3.0.6"
 
 "@types/connect@^3.4.33":
-  version "3.4.35"
-  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
-  integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
+  version "3.4.36"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.36.tgz#e511558c15a39cb29bd5357eebb57bd1459cd1ab"
+  integrity sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==
   dependencies:
     "@types/node" "*"
 
@@ -2177,16 +2177,16 @@ no-case@^3.0.4:
     tslib "^2.0.3"
 
 node-fetch@^2.6.12:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.12.tgz#02eb8e22074018e3d5a83016649d04df0e348fba"
-  integrity sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
 node-gyp-build@^4.3.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.6.0.tgz#0c52e4cbf54bbd28b709820ef7b6a3c2d6209055"
-  integrity sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.6.1.tgz#24b6d075e5e391b8d5539d98c7fc5c210cac8a3e"
+  integrity sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -2383,9 +2383,9 @@ rome@^12.0.0:
     "@rometools/cli-win32-x64" "12.1.3"
 
 rpc-websockets@^7.5.1:
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/rpc-websockets/-/rpc-websockets-7.5.1.tgz#e0a05d525a97e7efc31a0617f093a13a2e10c401"
-  integrity sha512-kGFkeTsmd37pHPMaHIgN1LVKXMi0JD782v4Ds9ZKtLlwdTKjn+CxM9A9/gLT2LaOuEcEFGL98h1QWQtlOIdW0w==
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/rpc-websockets/-/rpc-websockets-7.6.0.tgz#d3f4c0dac108ca35566b0e31552c32e58928cd04"
+  integrity sha512-Jgcs8q6t8Go98dEulww1x7RysgTkzpCMelVxZW4hvuyFtOGpeUz9prpr2KjUa/usqxgFCd9Tu3+yhHEP9GVmiQ==
   dependencies:
     "@babel/runtime" "^7.17.2"
     eventemitter3 "^4.0.7"
@@ -2447,44 +2447,44 @@ snake-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
-solana-bankrun-darwin-arm64@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/solana-bankrun-darwin-arm64/-/solana-bankrun-darwin-arm64-0.1.1.tgz#8854c9047f17c8822f7a85dc7c624e51a21efc25"
-  integrity sha512-BYGrp9bWVaHKvPthKSLTCXWK7zXtH2m4YM6mJg0rCvJeSoRJt7S5K2JER4gXm0LglDXeD5Bg7NL+QM24t2kQmg==
+solana-bankrun-darwin-arm64@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/solana-bankrun-darwin-arm64/-/solana-bankrun-darwin-arm64-0.2.0.tgz#747e27f38e30d9022c9cccdead2e8d37cf006d55"
+  integrity sha512-ENQ5Z/CYeY8ZVWIc2VutY/gMlBaHi93/kDw9w0iVwewoV+/YpQmP2irwrshIKu6ggRPTF3Ehlh2V6fGVIYWcXw==
 
-solana-bankrun-darwin-universal@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/solana-bankrun-darwin-universal/-/solana-bankrun-darwin-universal-0.1.1.tgz#c4c7a9d1ec9b38ad466e07fabbae7ae630a4da17"
-  integrity sha512-c/knJppc7hlmEBwKmFyQhAcGiIvh8UgteEn9CwsfcqpUZpu2qCDSV3+VJmcGmuYNlXt+IEK9lTcTD6qu6EoM6w==
+solana-bankrun-darwin-universal@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/solana-bankrun-darwin-universal/-/solana-bankrun-darwin-universal-0.2.0.tgz#5b325b49578d7a9d74b02f7a05741658e46fd073"
+  integrity sha512-HE45TvZXzBipm1fMn87+fkHeIuQ/KFAi5G/S29y/TLuBYt4RDI935RkWiT0rEQ7KwnwO6Y1aTsOaQXldY5R7uQ==
 
-solana-bankrun-darwin-x64@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/solana-bankrun-darwin-x64/-/solana-bankrun-darwin-x64-0.1.1.tgz#8c94e30c72ddc2451dfc0a9f2b750f2e5dba0aab"
-  integrity sha512-SMefIPsRVzhRXFpl0lcB+zNNm00b02yfm0cl+G3Abcm0v80Me7dNyv7QSLmwBzRXraSJOgHfobSfp610r9GA3g==
+solana-bankrun-darwin-x64@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/solana-bankrun-darwin-x64/-/solana-bankrun-darwin-x64-0.2.0.tgz#d03eafd69c8dd9a53c84e993660c67cc71d531de"
+  integrity sha512-42UsVrnac2Oo4UaIDo60zfI3Xn1i8W6fmcc9ixJQZNTtdO8o2/sY4mFxcJx9lhLMhda5FPHrQbGYgYdIs0kK0g==
 
-solana-bankrun-linux-x64-gnu@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/solana-bankrun-linux-x64-gnu/-/solana-bankrun-linux-x64-gnu-0.1.1.tgz#71cf5ee31ea7fdbc49580faf14bc82c915c46ed7"
-  integrity sha512-l4YUpD6Lkv0I2WHIAg6vNTQXTIARanGyMM8WozFqYlcyYKWm/iR8MQ/+HxCcUnbSpsFX02eYq8GiBbzjNaCiuA==
+solana-bankrun-linux-x64-gnu@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/solana-bankrun-linux-x64-gnu/-/solana-bankrun-linux-x64-gnu-0.2.0.tgz#eb133902e78afc5271ba034bd5353ad5f4005c10"
+  integrity sha512-WnqQjfBBdcI0ZLysjvRStI8gX7vm1c3CI6CC03lgkUztH+Chcq9C4LI9m2M8mXza8Xkn9ryeKAmX36Bx/yoVzg==
 
-solana-bankrun-linux-x64-musl@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/solana-bankrun-linux-x64-musl/-/solana-bankrun-linux-x64-musl-0.1.1.tgz#c2d10366acbb1d2ac85f4fa137a01230b1c92b5a"
-  integrity sha512-w9CtdJav2esrJISurzCiqk2hiJSqHrzmJkrnZoA22PjqrfCYRCX7zLnB4RQfZN9dM7/U8Z5z8LoMR55EhXQ7Tw==
+solana-bankrun-linux-x64-musl@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/solana-bankrun-linux-x64-musl/-/solana-bankrun-linux-x64-musl-0.2.0.tgz#a99c5187f34ab5979c708281da74093c64baab4a"
+  integrity sha512-8mtf14ZBoah30+MIJBUwb5BlGLRZyK5cZhCkYnC/ROqaIDN8RxMM44NL63gTUIaNHsFwWGA9xR0KSeljeh3PKQ==
 
-solana-bankrun@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/solana-bankrun/-/solana-bankrun-0.1.1.tgz#d1a1752de6a14dd4e215bb318b5c85100dfe2719"
-  integrity sha512-JkoU7yEyaJAZDMw5wGsFXOI/BNTk1lwcPX6Kgg9dBrCo0xs1VTn/ipwjKXwdRFLKF9N2kt4x+bLAipDp7W6GiA==
+solana-bankrun@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/solana-bankrun/-/solana-bankrun-0.2.0.tgz#e1df2126ee887b9eae17962f09db18aaa25d736f"
+  integrity sha512-TS6vYoO/9YJZng7oiLOVyuz8V7yLow5Hp4SLYWW71XM3702v+z9f1fvUBKudRfa4dfpta4tRNufApSiBIALxJQ==
   dependencies:
     "@solana/web3.js" "^1.68.0"
     bs58 "^4.0.1"
   optionalDependencies:
-    solana-bankrun-darwin-arm64 "0.1.1"
-    solana-bankrun-darwin-universal "0.1.1"
-    solana-bankrun-darwin-x64 "0.1.1"
-    solana-bankrun-linux-x64-gnu "0.1.1"
-    solana-bankrun-linux-x64-musl "0.1.1"
+    solana-bankrun-darwin-arm64 "0.2.0"
+    solana-bankrun-darwin-universal "0.2.0"
+    solana-bankrun-darwin-x64 "0.2.0"
+    solana-bankrun-linux-x64-gnu "0.2.0"
+    solana-bankrun-linux-x64-musl "0.2.0"
 
 source-map-support@0.5.13:
   version "0.5.13"
@@ -2666,9 +2666,9 @@ ts-node@^10.9.1:
     yn "3.1.1"
 
 tslib@^2.0.3:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
-  integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 type-detect@4.0.8:
   version "4.0.8"
@@ -2774,9 +2774,9 @@ ws@^7.4.5:
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
 ws@^8.5.0:
-  version "8.13.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
-  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
+  version "8.14.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.14.0.tgz#6c5792c5316dc9266ba8e780433fc45e6680aecd"
+  integrity sha512-WR0RJE9Ehsio6U4TuM+LmunEsjQ5ncHlw4sn9ihD6RoJKZrVyH9FWV3dmnwu8B2aNib1OvG2X6adUCyFpQyWcg==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
## Problem

`anchor-bankrun` currently needs `@coral-xyz/anchor`, `@solana/web3.js` and `solana-bankrun` but they are installed as normal dependencies. This makes `anchor-bankrun` use a private copy of these dependencies. This can cause issues like the following:

```
├── solana-bankrun@0.2.0
└─┬ anchor-bankrun@0.1.0
  └── solana-bankrun@0.1.1
```

## Solution

By using peer dependencies `anchor-bankrun` expects `solana-bankrun` to be there an be within a specific version range. Added benefit is that now every time we want to update `solana-bankrun`, `anchor-bankrun` will keep working.


```
├── solana-bankrun@0.2.0
└── anchor-bankrun@0.1.0
```