### PR TITLE
Handle missing logs in sendWithErr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.0] - Unreleased
+
+- Make `@solana/web3.js` a peer dependency [(#5)](https://github.com/kevinheavey/anchor-bankrun/pull/5)
+- Correctly handle missing transaction logs [(#10)](https://github.com/kevinheavey/anchor-bankrun/pull/10)
+
 ## [0.2.0] - 2023-09-08
 
 - Add better support for Anchor-like errors [(#6)](https://github.com/kevinheavey/anchor-bankrun/pull/6)

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,10 +68,15 @@ async function sendWithErr(
 	client: BanksClient,
 ) {
 	const res = await client.tryProcessTransaction(tx);
+	const maybeMeta = res.meta;
 	const errMsg = res.result;
 	if (errMsg !== null) {
-		const logs = res.meta.logMessages;
-		throw new SendTransactionError(errMsg, logs);
+		if (maybeMeta !== null) {
+			const logs = maybeMeta.logMessages;
+			throw new SendTransactionError(errMsg, logs);
+		} else {
+			throw new SendTransactionError(errMsg);
+		}
 	}
 }
 


### PR DESCRIPTION
fixes #9 

Typescript should have caught this since the type declaration looks like:
`get meta(): BanksTransactionMeta | null;`

So it should have pointed out that `const logs = res.meta.logMessages;` could fail.

But for some reason it didn't 😕