### PR TITLE
Fix error handling 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,9 +73,10 @@ async function sendWithErr(
 	if (errMsg !== null) {
 		if (maybeMeta !== null) {
 			const logs = maybeMeta.logMessages;
-			throw new SendTransactionError(errMsg, logs);
+			const formattedLogs = `Logs: \n${JSON.stringify(logs, null, 2)}`;
+			throw new Error(`${errMsg}\n${formattedLogs}`);
 		} else {
-			throw new SendTransactionError(errMsg);
+			throw new Error(errMsg);
 		}
 	}
 }


### PR DESCRIPTION
Sorry for breaking this. 

The SendTransactionError now expects an Object. 

When I added that object i noticed though that there is nothing printed when running Bankrun tests so i just changed it to a normal Error. 

Not sure how the output looked like before. Now it looks like this in an Error case: 
<img width="934" alt="image" src="https://github.com/user-attachments/assets/5cda0438-6d18-463f-9328-5eb4f2ed3734">
